### PR TITLE
feat: Audio Mix Optimization

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3833,6 +3833,7 @@ dependencies = [
  "ndarray",
  "open",
  "phire",
+ "rand 0.9.1",
  "regex",
  "sasa",
  "serde",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -48,6 +48,7 @@ serde_yaml = "0.9.21"
 tauri-plugin-prevent-default = "2.0.0"
 ndarray = "0.16.1"
 humantime = "2.2.0"
+rand = "0.9.1"
 # sysinfo = "0.29.0"
 
 [features]

--- a/src-tauri/config.toml
+++ b/src-tauri/config.toml
@@ -58,6 +58,7 @@ maxParticles = 5000 # 5000 25000 200000
 forceLimit = true
 hires = true
 loudnessEqualization = false
+AudioMixOptimization = true
 
 volumeMusic = 0.5
 volumeSfx = 0.4

--- a/src-tauri/src/render.rs
+++ b/src-tauri/src/render.rs
@@ -22,12 +22,13 @@ use serde::{Deserialize, Serialize};
 use std::{
     cell::RefCell,
     collections::HashMap,
+    cmp::Ordering,
     io::{BufRead, BufWriter, Write},
     ops::DerefMut,
     path::PathBuf,
     process::{Command, Stdio},
     rc::Rc,
-    sync::atomic::{AtomicBool, Ordering},
+    sync::atomic::{AtomicBool, Ordering as AtomicOrdering},
     time::Instant,
 };
 use std::{ffi::OsStr, fmt::Write as _};
@@ -572,17 +573,61 @@ pub async fn main(cmd: bool) -> Result<()> {
         let sfx_time = Instant::now();
         let judge_offset = config.judge_offset as f64;
         let length = chart_length as f32;
-        let mut count: u64 = 0;
+        let mut hit_fx_list: Vec<(f64, &Array1<f32>)> = Vec::new();
 
         chart.lines.iter().flat_map(|line| &line.notes).filter(|note| !note.fake && note.time < length).for_each(|note| {
             if let Some(sfx) = get_hitsound(&note) {
-                place_fx(before_time + note.time as f64 + judge_offset, sfx);
-                count += 1;
+                hit_fx_list.push((before_time + note.time as f64 + judge_offset, sfx));
+            }
+        });
+        let len = hit_fx_list.len();
+
+        hit_fx_list.sort_by(|(a1, b1), (a2, b2)| {
+            match a1.partial_cmp(a2).unwrap_or(Ordering::Equal) {
+                Ordering::Less  => Ordering::Less,
+                Ordering::Greater => Ordering::Greater,
+                Ordering::Equal => {
+                    let p1 = b1.as_ptr() as usize;
+                    let p2 = b2.as_ptr() as usize;
+                    p1.cmp(&p2)
+                }
             }
         });
 
+        let mut kept = Vec::with_capacity(hit_fx_list.len());
+        let mut last_arr: Option<&Array1<f32>> = None;
+        let mut last_t = 0.0;
+        let mut count = 0;
+
+        for &(pos, clip) in &hit_fx_list {
+            let is_new_group = match last_arr {
+                None => true,
+                Some(prev) => {
+                    !std::ptr::eq(prev, clip) || (pos - last_t).abs() > 0.01
+                }
+            };
+
+            if is_new_group {
+                last_arr = Some(clip);
+                last_t = pos;
+                count = 1;
+                kept.push((pos, clip));
+            } else {
+                count += 1;
+                if count <= 2 {
+                    kept.push((pos, clip));
+                }
+            }
+        }
+
+        hit_fx_list = kept;
+
+        for (pos, sfx) in hit_fx_list {
+            place_fx(pos, sfx);
+        }
+
         let elapsed = sfx_time.elapsed();
-        info!("Process Hit Effects Time: {:.2?} Speed: {:.2} notes/sec", elapsed, count as f32 / elapsed.as_secs_f32())
+        info!("Process Hit Effects Time: {:.2?} Speed: {:.2} notes/sec", elapsed, len as f32 / elapsed.as_secs_f32())
     }
 
     let output_music_temp = NamedTempFile::new()?;
@@ -677,10 +722,10 @@ pub async fn main(cmd: bool) -> Result<()> {
             move || {
                 cnt += 1;
                 if cnt == 1 || cnt == 3 {
-                    MSAA.store(true, Ordering::SeqCst);
+                    MSAA.store(true, AtomicOrdering::SeqCst);
                     Some(mst.input())
                 } else {
-                    MSAA.store(false, Ordering::SeqCst);
+                    MSAA.store(false, AtomicOrdering::SeqCst);
                     Some(mst.output())
                 }
             }
@@ -900,7 +945,7 @@ pub async fn main(cmd: bool) -> Result<()> {
         }
         gl.flush();
 
-        if MSAA.load(Ordering::SeqCst) {
+        if MSAA.load(AtomicOrdering::SeqCst) {
             mst.blit();
         }
 

--- a/src-tauri/src/render.rs
+++ b/src-tauri/src/render.rs
@@ -74,6 +74,7 @@ pub struct RenderConfig {
     pub force_limit: bool,
     pub limit_threshold: f32,
     pub loudness_equalization: bool,
+    pub audio_mix_optimization: bool,
     pub watermark: String,
     pub roman: bool,
     pub chinese: bool,
@@ -191,6 +192,7 @@ impl Default for RenderConfig {
             force_limit: true,
             limit_threshold: 0.5,
             loudness_equalization: false,
+            audio_mix_optimization: true,
             chart_debug_line: 0.0,
             chart_debug_note: 0.0,
             chart_ratio: 1.0,
@@ -575,61 +577,74 @@ pub async fn main(cmd: bool) -> Result<()> {
         let length = chart_length as f32;
         let mut hit_fx_list: Vec<(f64, &Array1<f32>)> = Vec::new();
 
-        chart.lines.iter().flat_map(|line| &line.notes).filter(|note| !note.fake && note.time < length).for_each(|note| {
-            if let Some(sfx) = get_hitsound(&note) {
-                hit_fx_list.push((before_time + note.time as f64 + judge_offset, sfx));
-            }
-        });
-        let len = hit_fx_list.len();
-
-        hit_fx_list.sort_by(|(a1, b1), (a2, b2)| {
-            match a1.partial_cmp(a2).unwrap_or(Ordering::Equal) {
-                Ordering::Less  => Ordering::Less,
-                Ordering::Greater => Ordering::Greater,
-                Ordering::Equal => {
-                    let p1 = b1.as_ptr() as usize;
-                    let p2 = b2.as_ptr() as usize;
-                    p1.cmp(&p2)
+        if config.audio_mix_optimization {
+            chart.lines.iter().flat_map(|line| &line.notes).filter(|note| !note.fake && note.time < length).for_each(|note| {
+                if let Some(sfx) = get_hitsound(&note) {
+                    hit_fx_list.push((before_time + note.time as f64 + judge_offset, sfx));
                 }
-            }
-        });
+            });
+            let len = hit_fx_list.len();
 
-        let mut kept = Vec::with_capacity(hit_fx_list.len());
-        let mut last_arr: Option<&Array1<f32>> = None;
-        let mut last_t = 0.0;
-        let mut count = 0;
-        let mut offset = 0.0;
-
-        for &(pos, clip) in &hit_fx_list {
-            let is_new_group = match last_arr {
-                None => true,
-                Some(prev) => {
-                    !std::ptr::eq(prev, clip) || (pos - last_t).abs() > 0.005
+            hit_fx_list.sort_by(|(a1, b1), (a2, b2)| {
+                match a1.partial_cmp(a2).unwrap_or(Ordering::Equal) {
+                    Ordering::Less  => Ordering::Less,
+                    Ordering::Greater => Ordering::Greater,
+                    Ordering::Equal => {
+                        let p1 = b1.as_ptr() as usize;
+                        let p2 = b2.as_ptr() as usize;
+                        p1.cmp(&p2)
+                    }
                 }
-            };
+            });
 
-            if is_new_group {
-                last_arr = Some(clip);
-                last_t = pos;
-                count = 1;
-                offset = rand::gen_range(0.000, 0.002);
-                kept.push((pos + offset, clip));
-            } else {
-                count += 1;
-                if count <= 2 {
+            let mut kept = Vec::with_capacity(hit_fx_list.len());
+            let mut last_arr: Option<&Array1<f32>> = None;
+            let mut last_t = 0.0;
+            let mut count = 0;
+            let mut offset = 0.0;
+
+            for &(pos, clip) in &hit_fx_list {
+                let is_new_group = match last_arr {
+                    None => true,
+                    Some(prev) => {
+                        !std::ptr::eq(prev, clip) || (pos - last_t).abs() > 0.005
+                    }
+                };
+
+                if is_new_group {
+                    last_arr = Some(clip);
+                    last_t = pos;
+                    count = 1;
+                    offset = rand::gen_range(0.000, 0.002);
                     kept.push((pos + offset, clip));
+                } else {
+                    count += 1;
+                    if count <= 2 {
+                        kept.push((pos + offset, clip));
+                    }
                 }
             }
+
+            hit_fx_list = kept;
+            let num = hit_fx_list.len();
+            for (pos, sfx) in hit_fx_list {
+                place_fx(pos, sfx);
+            }
+
+            let elapsed = sfx_time.elapsed();
+            info!("Process Hit Effects Time: {:.2?} Equivalent Speed: {:.2} notes/sec Speed: {:.2} notes/sec", elapsed, len as f32 / elapsed.as_secs_f32(), num as f32 / elapsed.as_secs_f32())
+        } else {
+            let mut num = 0;
+            chart.lines.iter().flat_map(|line| &line.notes).filter(|note| !note.fake && note.time < length).for_each(|note| {
+                if let Some(sfx) = get_hitsound(&note) {
+                    place_fx(before_time + note.time as f64 + judge_offset, sfx);
+                    num += 1;
+                }
+            });
+
+            let elapsed = sfx_time.elapsed();
+            info!("Process Hit Effects Time: {:.2?} Speed: {:.2} notes/sec", elapsed, num as f32 / elapsed.as_secs_f32())
         }
-
-        hit_fx_list = kept;
-
-        for (pos, sfx) in hit_fx_list {
-            place_fx(pos, sfx);
-        }
-
-        let elapsed = sfx_time.elapsed();
-        info!("Process Hit Effects Time: {:.2?} Speed: {:.2} notes/sec", elapsed, len as f32 / elapsed.as_secs_f32())
     }
 
     let output_music_temp = NamedTempFile::new()?;

--- a/src-tauri/src/render.rs
+++ b/src-tauri/src/render.rs
@@ -598,12 +598,13 @@ pub async fn main(cmd: bool) -> Result<()> {
         let mut last_arr: Option<&Array1<f32>> = None;
         let mut last_t = 0.0;
         let mut count = 0;
+        let mut offset = 0.0;
 
         for &(pos, clip) in &hit_fx_list {
             let is_new_group = match last_arr {
                 None => true,
                 Some(prev) => {
-                    !std::ptr::eq(prev, clip) || (pos - last_t).abs() > 0.01
+                    !std::ptr::eq(prev, clip) || (pos - last_t).abs() > 0.005
                 }
             };
 
@@ -611,11 +612,12 @@ pub async fn main(cmd: bool) -> Result<()> {
                 last_arr = Some(clip);
                 last_t = pos;
                 count = 1;
-                kept.push((pos, clip));
+                offset = rand::gen_range(0.000, 0.002);
+                kept.push((pos + offset, clip));
             } else {
                 count += 1;
                 if count <= 2 {
-                    kept.push((pos, clip));
+                    kept.push((pos + offset, clip));
                 }
             }
         }

--- a/src-tauri/src/render.rs
+++ b/src-tauri/src/render.rs
@@ -619,7 +619,7 @@ pub async fn main(cmd: bool) -> Result<()> {
                     kept.push((pos + offset, clip));
                 } else {
                     count += 1;
-                    if count <= 2 {
+                    if count <= 3 {
                         kept.push((pos + offset, clip));
                     }
                 }

--- a/src/components/ConfigView.vue
+++ b/src/components/ConfigView.vue
@@ -65,7 +65,7 @@ const expandList = ref(t('expand-list').split(','))
 const expand = ref<string[]>([])
 
 const audioList = ref(t('audio-list').split(','))
-const audio = ref([audioList.value[0]])
+const audio = ref([audioList.value[0], audioList.value[3]])
 
 const
   combo = ref(DEFAULT_RENDER_CONFIG.combo),
@@ -278,6 +278,7 @@ async function buildConfig(): Promise<RenderConfig | null> {
     forceLimit: audio.value.includes(audioList.value[0]),
     hires: audio.value.includes(audioList.value[1]),
     loudnessEqualization: audio.value.includes(audioList.value[2]),
+    audioMixOptimization: audio.value.includes(audioList.value[3]),
 
     maxParticles: maxParticles.value,
     renderStartTime: parseFloat(renderStartTime.value),
@@ -384,6 +385,7 @@ function applyConfig(config: RenderConfig) {
   if (config.forceLimit) audio.value.push(audioList.value[0]);
   if (config.hires) audio.value.push(audioList.value[1]);
   if (config.loudnessEqualization) audio.value.push(audioList.value[2]);
+  if (config.audioMixOptimization) audio.value.push(audioList.value[3]);
 
   maxParticles.value = config.maxParticles;
   const index = maxParticlesList.indexOf(maxParticles.value);

--- a/src/locales/en/config.json
+++ b/src/locales/en/config.json
@@ -74,7 +74,7 @@
     "expand": "Expand",
     "expand-list": "Aggressive Optimization,Roman Mode,Chinese Mode",
     "audio-expand": "Audio Expand",
-    "audio-list": "SFX Force Limit,Lossless Audio,Music Loudness Equalization (-16 LUFS)",
+    "audio-list": "SFX Force Limit,Lossless Audio,Music Loudness Equalization (-16 LUFS),Audio Mix Optimization",
     "others": "More",
     "selects": "Selected",
     "ffmpeg-preset-list": "VeryFast,Faster,Fast,Medium,Slow,Slower,VerySlow",

--- a/src/locales/zh-CN/config.json
+++ b/src/locales/zh-CN/config.json
@@ -74,7 +74,7 @@
     "expand": "拓展内容",
     "expand-list": "激进优化,罗马模式,中文模式",
     "audio-expand": "音频拓展内容",
-    "audio-list": "音效强制限幅,无损音频,音乐响度均衡 (-16 LUFS)",
+    "audio-list": "音效强制限幅,无损音频,音乐响度均衡 (-16 LUFS),混音优化",
     "others": "更多",
     "selects": "已选中",
     "ffmpeg-preset-list": "非常快,更快,快,中等,好,更好,非常好",

--- a/src/model.ts
+++ b/src/model.ts
@@ -113,6 +113,7 @@ export interface RenderConfig {
   forceLimit: boolean;
   limitThreshold: number;
   loudnessEqualization: boolean;
+  audioMixOptimization: boolean;
   simpleFileName: boolean;
 
   renderLine: boolean;
@@ -174,6 +175,7 @@ export const DEFAULT_RENDER_CONFIG: RenderConfig = {
   forceLimit: true,
   limitThreshold: 0.5,
   loudnessEqualization: false,
+  audioMixOptimization: true,
   watermark: '',
   roman: false,
   chinese: false,


### PR DESCRIPTION
不允许同一音频叠加大于 3 次，修复叠加过多时的严重爆音 (打击音可以适当的爆音以增加对比度，不会对音质造成负面影响)
对每组不重叠的不同音频进行随机偏移，修复不完全重叠的音频会互相影响频率 (模拟实时预览时的效果，不会对听感造成负面影响)