### PR TITLE
refactor: Audio Mix Optimization

### DIFF
--- a/src-tauri/src/render.rs
+++ b/src-tauri/src/render.rs
@@ -371,6 +371,10 @@ pub fn test_encoder(ffmpeg: &String, encoder: &str) -> bool {
     output.status.success()
 }
 
+fn round_to_step(v: f64, step: f64) -> f64 {
+    (v / step).round() * step
+}
+
 pub async fn main(cmd: bool) -> Result<()> {
     let loading_time = Instant::now();
 
@@ -601,26 +605,27 @@ pub async fn main(cmd: bool) -> Result<()> {
             let mut last_arr: Option<&Array1<f32>> = None;
             let mut last_t = 0.0;
             let mut count = 0;
-            let mut offset = 0.0;
 
             for &(pos, clip) in &hit_fx_list {
                 let is_new_group = match last_arr {
                     None => true,
                     Some(prev) => {
+                        let pos = round_to_step(pos, 0.005);
                         !std::ptr::eq(prev, clip) || (pos - last_t).abs() > 0.005
                     }
                 };
 
                 if is_new_group {
                     last_arr = Some(clip);
+                    let pos = round_to_step(pos, 0.005);
                     last_t = pos;
                     count = 1;
-                    offset = rand::gen_range(0.000, 0.002);
-                    kept.push((pos + offset, clip));
+                    kept.push((pos, clip));
                 } else {
                     count += 1;
                     if count <= 3 {
-                        kept.push((pos + offset, clip));
+                        let pos = round_to_step(pos, 0.005);
+                        kept.push((pos, clip));
                     }
                 }
             }

--- a/src-tauri/src/render.rs
+++ b/src-tauri/src/render.rs
@@ -607,24 +607,22 @@ pub async fn main(cmd: bool) -> Result<()> {
             let mut count = 0;
 
             for &(pos, clip) in &hit_fx_list {
+                let pos = round_to_step(pos, 0.005);
                 let is_new_group = match last_arr {
                     None => true,
                     Some(prev) => {
-                        let pos = round_to_step(pos, 0.005);
                         !std::ptr::eq(prev, clip) || (pos - last_t).abs() > 0.005
                     }
                 };
 
                 if is_new_group {
                     last_arr = Some(clip);
-                    let pos = round_to_step(pos, 0.005);
                     last_t = pos;
                     count = 1;
                     kept.push((pos, clip));
                 } else {
                     count += 1;
                     if count <= 3 {
-                        let pos = round_to_step(pos, 0.005);
                         kept.push((pos, clip));
                     }
                 }


### PR DESCRIPTION
打击音的播放受到播放帧率的限制，上一个 pr 采用随机偏移的方式但效果并不好，实际上应该取整到一个和帧间隔相近的数，这里采用了 0.005