### PR TITLE
refactor: filename

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3859,7 +3859,7 @@ dependencies = [
 [[package]]
 name = "phire"
 version = "0.4.0"
-source = "git+https://github.com/2278535805/phire#fddd1c998e0c4f85af930b13c41323ec7dc7c7de"
+source = "git+https://github.com/2278535805/phire#ac8eea0a90cbe7db0ccd615f1263629fd61609c2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4083,7 +4083,7 @@ dependencies = [
 [[package]]
 name = "prpr-avc"
 version = "0.1.0"
-source = "git+https://github.com/2278535805/phire#fddd1c998e0c4f85af930b13c41323ec7dc7c7de"
+source = "git+https://github.com/2278535805/phire#ac8eea0a90cbe7db0ccd615f1263629fd61609c2"
 dependencies = [
  "anyhow",
  "tracing",

--- a/src-tauri/src/render.rs
+++ b/src-tauri/src/render.rs
@@ -84,7 +84,7 @@ pub struct RenderConfig {
     pub combo: String,
     pub difficulty: String,
     pub judge_offset: f32,
-    pub simple_file_name: bool,
+    pub file_name_format: String,
 
     pub render_line: bool,
     pub render_line_extra: bool,
@@ -208,7 +208,7 @@ impl Default for RenderConfig {
             difficulty: "".to_string(),
             player_avatar: None,
             judge_offset: 0.,
-            simple_file_name: false,
+            file_name_format: "%date% %time% %info.name%_%info.difficulty%".to_string(),
 
             render_line: true,
             render_line_extra: true,

--- a/src-tauri/src/task.rs
+++ b/src-tauri/src/task.rs
@@ -8,6 +8,7 @@ use crate::{
 use anyhow::Result;
 use chrono::Local;
 use phire::{fs, info::ChartInfo};
+use regex::Regex;
 use serde::Serialize;
 use tracing::{error, info};
 use std::{
@@ -53,6 +54,132 @@ pub enum TaskStatus {
 }
 
 pub fn generate_filename(info: &ChartInfo, config: &RenderConfig) -> String {
+    let re = Regex::new(r"%([^%]+)%").unwrap();
+    let input = config.file_name_format.as_str();
+    let mut output = input.to_string();
+
+    let match_config = |key: &str| -> String {
+        match key {
+            "resolution"                 => format!("{}x{}", config.resolution.0, config.resolution.1),
+            "ffmpeg_preset"              => config.ffmpeg_preset.clone(),
+            "ending_length"              => config.ending_length.to_string(),
+            "disable_loading"            => config.disable_loading.to_string(),
+            "hires"                      => config.hires.to_string(),
+            "chart_debug_line"           => config.chart_debug_line.to_string(),
+            "chart_debug_note"           => config.chart_debug_note.to_string(),
+            "chart_ratio"                => config.chart_ratio.to_string(),
+            "all_good"                   => config.all_good.to_string(),
+            "all_bad"                    => config.all_bad.to_string(),
+            "fps"                        => config.fps.to_string(),
+            "hardware_accel"             => config.hardware_accel.to_string(),
+            "hevc"                       => config.hevc.to_string(),
+            "mpeg4"                      => config.mpeg4.to_string(),
+            "custom_encoder"             => config.custom_encoder.clone().unwrap_or_default(),
+            "dynamic_bitrate_control"    => config.dynamic_bitrate_control.to_string(),
+            "bitrate"                    => config.bitrate.clone(),
+            "aggressive"                 => config.aggressive.to_string(),
+            "challenge_color"            => config.challenge_color.to_string(),
+            "challenge_rank"             => config.challenge_rank.to_string(),
+            "fxaa"                       => config.fxaa.to_string(),
+            "note_scale"                 => config.note_scale.to_string(),
+            "particle"                   => config.particle.to_string(),
+            "player_avatar"              => config.player_avatar.clone().unwrap_or_default(),
+            "player_name"                => config.player_name.clone(),
+            "player_rks"                 => config.player_rks.to_string(),
+            "sample_count"               => config.sample_count.to_string(),
+            "res_pack_path"              => config.res_pack_path.clone().unwrap_or_default(),
+            "speed"                      => config.speed.to_string(),
+            "volume_music"               => config.volume_music.to_string(),
+            "volume_sfx"                 => config.volume_sfx.to_string(),
+            "compression_ratio"          => config.compression_ratio.to_string(),
+            "force_limit"                => config.force_limit.to_string(),
+            "limit_threshold"            => config.limit_threshold.to_string(),
+            "loudness_equalization"      => config.loudness_equalization.to_string(),
+            "audio_mix_optimization"     => config.audio_mix_optimization.to_string(),
+            "watermark"                  => config.watermark.clone(),
+            "roman"                      => config.roman.to_string(),
+            "chinese"                    => config.chinese.to_string(),
+            "combo"                      => config.combo.clone(),
+            "difficulty"                 => config.difficulty.clone(),
+            "judge_offset"               => config.judge_offset.to_string(),
+            "file_name_format"           => config.file_name_format.clone(),
+            "render_line"                => config.render_line.to_string(),
+            "render_line_extra"          => config.render_line_extra.to_string(),
+            "render_note"                => config.render_note.to_string(),
+            "render_double_hint"         => config.render_double_hint.to_string(),
+            "render_ui_pause"            => config.render_ui_pause.to_string(),
+            "render_ui_name"             => config.render_ui_name.to_string(),
+            "render_ui_level"            => config.render_ui_level.to_string(),
+            "render_ui_score"            => config.render_ui_score.to_string(),
+            "render_ui_combo"            => config.render_ui_combo.to_string(),
+            "render_ui_bar"              => config.render_ui_bar.to_string(),
+            "render_bg"                  => config.render_bg.to_string(),
+            "render_bg_dim"              => config.render_bg_dim.to_string(),
+            "render_extra"               => config.render_extra.to_string(),
+            "bg_blurriness"              => config.bg_blurriness.to_string(),
+            "max_particles"              => config.max_particles.to_string(),
+            "render_start_time"          => config.render_start_time.to_string(),
+            "render_end_time"            => config.render_end_time.map_or_else(String::new, |v| v.to_string()),
+            "fade"                       => config.fade.to_string(),
+            "alpha_tint"                 => config.alpha_tint.to_string(),
+            _                            => key.to_string(),
+        }
+    };
+
+
+    let match_info = |key: &str| -> String {
+        match key {
+            "id"                 => info.id.map_or_else(String::new, |v| v.to_string()),
+            "uploader"           => info.uploader.map_or_else(String::new, |v| v.to_string()),
+            "name"               => info.name.clone(),
+            "difficulty"         => info.difficulty.to_string(),
+            "level"              => info.level.clone(),
+            "charter"            => info.charter.clone(),
+            "composer"           => info.composer.clone(),
+            "illustrator"        => info.illustrator.clone(),
+            "chart"              => info.chart.clone(),
+            "music"              => info.music.clone(),
+            "illustration"       => info.illustration.clone(),
+            "preview_start"      => info.preview_start.to_string(),
+            "preview_end"        => info.preview_end.map_or_else(String::new, |v| v.to_string()),
+            "aspect_ratio"       => info.aspect_ratio.to_string(),
+            "force_aspect_ratio" => info.force_aspect_ratio.to_string(),
+            "background_dim"     => info.background_dim.to_string(),
+            "line_length"        => info.line_length.to_string(),
+            "offset"             => info.offset.to_string(),
+            "tip"                => info.tip.clone().unwrap_or_default(),
+            "tags"               => info.tags.join(","),
+            "intro"              => info.intro.clone(),
+            "hold_partial_cover" => info.hold_partial_cover.to_string(),
+            "note_uniform_scale" => info.note_uniform_scale.to_string(),
+            "score_total"        => info.score_total.to_string(),
+            "created"            => info.created.map(|dt| dt.to_rfc3339()).unwrap_or_default(),
+            "updated"            => info.updated.map(|dt| dt.to_rfc3339()).unwrap_or_default(),
+            "chart_updated"      => info.chart_updated.map(|dt| dt.to_rfc3339()).unwrap_or_default(),
+            _                    => key.to_string(),
+        }
+    };
+
+
+    for caps in re.captures_iter(input) {
+        let whole = caps.get(0).unwrap().as_str();
+        let key   = caps.get(1).unwrap().as_str();
+
+        let replacement =
+            if let Some(key) = key.strip_prefix("config.") {
+                match_config(key)
+            } else if let Some(key) = key.strip_prefix("info.") {
+                match_info(key)
+            } else {
+                match key {
+                    "date" => Local::now().format("%Y-%m-%d").to_string(),
+                    "time" => Local::now().format("%H-%M-%S").to_string(),
+                    _ => whole.to_string(),
+                }
+            };
+        output = output.replace(whole, &replacement);
+    }
+
     fn safe_filename(name: String) -> String {
         name
             .trim()
@@ -61,26 +188,9 @@ pub fn generate_filename(info: &ChartInfo, config: &RenderConfig) -> String {
             .collect()
     }
 
-    let safe_level = safe_filename(
-            info
-            .level
-            .split_whitespace()
-            .next()
-            .unwrap_or("UK")
-            .to_string()
-        );
-    let safe_name = safe_filename(info.name.clone());
     let format = if config.hires { "mov" } else { "mp4" };
 
-    if config.simple_file_name {
-        let safe_composer = safe_filename(info.composer.clone());
-        format!("{safe_name}.{safe_composer}_{safe_level}.{format}",)
-    } else {
-        format!(
-            "{} {safe_name}_{safe_level}.{format}",
-            Local::now().format("%Y-%m-%d %H-%M-%S")
-        )
-    }
+    format!("{}.{}", safe_filename(output), format)
 }
 
 pub struct Task {

--- a/src/BatchView.vue
+++ b/src/BatchView.vue
@@ -58,7 +58,6 @@ const disSelectStartRender = useStorage<boolean>('BatchView.disSelectStartRender
 const removeStartRender = useStorage<boolean>('BatchView.removeStartRender', false);
 const removeAfterRender = useStorage<boolean>('BatchView.removeAfterRender', false);
 const autoChangeAspectRatio = useStorage<boolean>('BatchView.autoChangeAspectRatio', false);
-const simpleFileName = useStorage<boolean>('BatchView.simpleFileName', false);
 
 
 async function chooseChart(folder?: boolean) {
@@ -138,7 +137,6 @@ async function buildParams(chartPath: string, chartInfo: ChartInfo, config: Rend
 async function postRender(chart: RenderChart) {
   let config = preset.value.config;
   if (autoChangeAspectRatio.value) { applyAspectRatio(config.resolution, chart.chartInfo.aspectRatio); }
-  if (simpleFileName.value) { preset.value.config.simpleFileName = true; } else { preset.value.config.simpleFileName = false; }
   let params = await buildParams(chart.path, chart.chartInfo, config);
   if (!params) return false;
   try {
@@ -379,9 +377,6 @@ const outputDialog = ref(false),
             </v-row>
             <v-row no-gutters>
               <v-checkbox :label="t('choose.auto-change-aspect-ratio')" v-model="autoChangeAspectRatio"></v-checkbox>
-            </v-row>
-            <v-row no-gutters>
-              <v-checkbox :label="t('choose.simple-file-name')" v-model="simpleFileName"></v-checkbox>
             </v-row>
           </v-list-item>
         </v-list>

--- a/src/components/ConfigView.vue
+++ b/src/components/ConfigView.vue
@@ -18,6 +18,7 @@ import TooltipIcon from './TooltipIcon.vue';
 
 const form = ref<VForm>();
 const page = ref(0);
+const fileNameFormatDialog = ref(false);
 
 const RESOLUTIONS = [ '1280x720', '1920x1080', '1620x1080', '1440x1080', '2560x1440', '2844x1600', '2388x1668', '3840x2160']
 const ffmpegPresetPresetTextList = t('ffmpeg-preset-list').split(','),
@@ -71,7 +72,7 @@ const
   combo = ref(DEFAULT_RENDER_CONFIG.combo),
   difficulty = ref(DEFAULT_RENDER_CONFIG.difficulty),
   judgeOffset = ref(String(DEFAULT_RENDER_CONFIG.judgeOffset)),
-  simpleFileName = ref(DEFAULT_RENDER_CONFIG.simpleFileName),
+  fileNameFormat = ref(DEFAULT_RENDER_CONFIG.fileNameFormat),
   bgBlurriness = ref(String(DEFAULT_RENDER_CONFIG.bgBlurriness)),
   watermark = ref(DEFAULT_RENDER_CONFIG.watermark)
 
@@ -252,7 +253,7 @@ async function buildConfig(): Promise<RenderConfig | null> {
     combo: combo.value,
     difficulty: difficulty.value,
     judgeOffset: parseInt(judgeOffset.value) / 1000,
-    simpleFileName: simpleFileName.value,
+    fileNameFormat: fileNameFormat.value,
     bgBlurriness: parseFloat(bgBlurriness.value),
     
     disableLoading: !render.value.includes(renderList.value[0]),
@@ -657,10 +658,10 @@ async function replacePreset() {
           <v-combobox class="mr-1" :label="t('respack')" :rues="[RULES.notEmpty]" :items="respacks" item-title="name" v-model="respack"></v-combobox>
         </v-col>
         <v-col cols="2" class="d-flex justify-center">
-          <v-btn class="pa-1 text-caption" color="btn-large" size="large" @click="updateRespacks" v-t="'respack-refresh'" style="flex: .9;"></v-btn>
+          <v-btn class="config-btn pa-1 text-caption" color="btn-large" size="large" @click="updateRespacks" v-t="'respack-refresh'" style="flex: .9;"></v-btn>
         </v-col>
         <v-col cols="2" class="d-flex justify-center">
-          <v-btn class="pa-1 text-caption" color="btn-large" size="large" @click="openRespackFolder" v-t="'respack-open'" style="flex: .9;"></v-btn>
+          <v-btn class="config-btn pa-1 text-caption" color="btn-large" size="large" @click="openRespackFolder" v-t="'respack-open'" style="flex: .9;"></v-btn>
         </v-col>
       </v-row>
       <v-row no-gutters class="mx-n2 mt-6 align-center">
@@ -757,13 +758,30 @@ async function replacePreset() {
         </v-col>
       </v-row>
       <v-row no-gutters class="mx-n2 mt-2">
+        <v-col cols="9">
+          <v-text-field class="mx-2" :label="t('file-name-format')" v-model="fileNameFormat" type="text" :rules="[RULES.notEmpty, RULES.notNull]" append-inner-icon="mdi-help-circle-outline" @click:append-inner="fileNameFormatDialog = true"></v-text-field>
+        </v-col>
         <v-col cols="3">
-          <v-switch class="mx-4" :label="t('alpha-tint')" color="btn" :title="t('alpha-tint-tip')" v-model="alphaTint"></v-switch>
+          <v-switch class="text-center justify-center mr-2 d-flex" :label="t('alpha-tint')" color="btn" :title="t('alpha-tint-tip')" v-model="alphaTint"></v-switch>
         </v-col>
       </v-row>
       <v-row no-gutters class="mt-2" />
     </div>
   </v-form>
+
+  <v-dialog v-model="fileNameFormatDialog" width="850px" class="log-card-bg">
+    <v-card class="log-card-only-window" style="background: rgba(var(--v-theme-dialog), 0.4) !important;">
+      <v-card-title v-t="'file-name-format'"> </v-card-title>
+      <v-card-text>
+        <v-text-field class="" :label="t('file-name-format')" v-model="fileNameFormat" type="text" :rules="[RULES.notEmpty, RULES.notNull]"></v-text-field>
+        <pre class="mx-2">{{ t('file-name-format-tip') }}</pre>
+
+      </v-card-text>
+      <v-card-actions class="justify-end">
+        <v-btn class="hover-scale" variant="text" @click="fileNameFormatDialog = false" v-t="'close'"></v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
 </template>
 
 <style scoped>
@@ -789,7 +807,7 @@ async function replacePreset() {
   /* box-shadow: 0 !important; */
 }
 
-.v-btn {
+.config-btn {
   background: rgba(54, 50, 98, 1);
   transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
 }

--- a/src/locales/en/batch.json
+++ b/src/locales/en/batch.json
@@ -9,7 +9,6 @@
     "remove-after-render": "Remove after rendering is completed",
     "post-select-render": "Render",
     "auto-change-aspect-ratio": "Auto Change Aspect Ratio",
-    "simple-file-name": "Simple File Name",
     "chart-info": "Chart Info",
     "edit": "Edit",
     "sort-tip": "Click to sort, right-click to reverse",

--- a/src/locales/en/config.json
+++ b/src/locales/en/config.json
@@ -69,6 +69,8 @@
     "difficulty": "Custom Difficulty",
     "offset": "Offset",
     "judgeOffset": "Judge Offset",
+    "file-name-format": "File Name Format",
+    "file-name-format-tip": "supports variables:\n %date% \n %time% \n %info.*% \n %config.*%",
     "renders": "Render",
     "render-list": "Loading Screen,Judge Line,Other Judge Line,Note,Pause Button,Name,Difficulty,Score,Combo Number,Progress Bar,Background,Background Dim,Hit Effects,Extra (Shader),Double Hint",
     "expand": "Expand",

--- a/src/locales/zh-CN/batch.json
+++ b/src/locales/zh-CN/batch.json
@@ -9,7 +9,6 @@
     "remove-after-render": "渲染完成后移除",
     "post-select-render": "渲染",
     "auto-change-aspect-ratio": "自动调整宽高比",
-    "simple-file-name": "简单文件名",
     "chart-info": "谱面信息",
     "edit": "编辑",
     "sort-tip": "点击排序 右键反转",

--- a/src/locales/zh-CN/config.json
+++ b/src/locales/zh-CN/config.json
@@ -69,6 +69,8 @@
     "difficulty": "自定义难度",
     "offset": "延时",
     "judgeOffset": "判定偏移",
+    "file-name-format": "文件名格式",
+    "file-name-format-tip": "支持以下变量:\n %date% \n %time% \n %info.*% \n %config.*%",
     "renders": "渲染内容",
     "render-list": "加载画面,判定线,其他判定线,音符,暂停按钮,曲目名称,谱面难度,分数,连击数,进度条,背景,背景压暗,打击特效,额外内容 (着色器),双押提示",
     "expand": "拓展内容",

--- a/src/model.ts
+++ b/src/model.ts
@@ -114,7 +114,7 @@ export interface RenderConfig {
   limitThreshold: number;
   loudnessEqualization: boolean;
   audioMixOptimization: boolean;
-  simpleFileName: boolean;
+  fileNameFormat: string;
 
   renderLine: boolean;
   renderLineExtra: boolean;
@@ -182,7 +182,7 @@ export const DEFAULT_RENDER_CONFIG: RenderConfig = {
   combo: 'AUTOPLAY',
   difficulty: '',
   judgeOffset: 0,
-  simpleFileName: false,
+  fileNameFormat: '%date% %time% %info.name%_%info.difficulty%',
   renderLine: true,
   renderLineExtra: true,
   renderNote: true,


### PR DESCRIPTION
重构了文件名的生成，支持变量替换
  - `%date%`: 日期, 格式为 `YYYY-MM-DD`
  - `%time%`: 时间, 格式为 `HH-mm-ss`
  - `%info.*%`: 谱面信息中的字段, 可参考谱面信息结构
  - `%config.*%`: 渲染设置中的字段, 可参考渲染设置结构
